### PR TITLE
Only set floating modifier once

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ floating konsole
 ```
 
 Opens a floating instance of konsole.
+
+Note: This changes the container floating property based on the PID of the spawning process. Some programs such as browsers will not necessarily use the same PID as the spawning process (for example if it was opened in an existing session).

--- a/floating
+++ b/floating
@@ -1,18 +1,10 @@
 #!/usr/bin/env bash
-
 $@ &
-pid=$!
-
-swaymsg -t subscribe -m '[ "window" ]' \
-  | jq --unbuffered --argjson pid "$pid" '.container | select(.pid == $pid) | .id' \
-  | xargs -I '@' -- swaymsg '[ con_id=@ ] floating enable' &
-
-subscription=$!
-
-echo Going into wait state
-
-# Wait for our process to close
-tail --pid=$pid -f /dev/null
-
-echo Killing subscription
-kill $subscription
+# subscribe to window events from sway IPC
+# process events with JQ, searching for a container using that PID and output its container ID
+# take only the first intance of the container
+# enable floating mode on it
+swaymsg -mt subscribe '[ "window" ]' \
+  | jq --unbuffered --argjson pid "$!" 'select(.container.pid == $pid) | .container.id' \
+  | head -n1 \
+  | swaymsg "[ con_id=$(cat) ] floating enable"


### PR DESCRIPTION
The current implementation re-applies the floating modifier for every window event. So if I have a hotkey to un-float windows it will not work because that event will immediately re-trigger a float. The new implementation simply waits for the first event with the correct PID and applies the float once.

This also coincidentally simplifies the subscription cleanup logic, since there is no need to have a long running subscription